### PR TITLE
Add pre-commit hooks to prevent CI failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,24 +120,36 @@ Claude Code slash commands are markdown files stored in `.claude/commands/` that
 ### Local Development
 
 ```bash
-# Install pre-commit hooks (optional but recommended)
+# Set up pre-commit hooks (automated quality checks - RECOMMENDED)
+./install.sh --hooks
+
+# Alternative manual setup:
 pip install pre-commit
 pre-commit install
 
-# Run linting
-npm install -g markdownlint-cli
-markdownlint --config .markdownlint.json *.md .claude/commands/*.md
-
-# Install shellcheck (varies by OS)
-# macOS: brew install shellcheck
-# Ubuntu: sudo apt-get install shellcheck
+# Run linting manually
+npm run lint
 
 # Run tests
-./tests/test_commands.sh
+npm test
 
-# Test update functionality
-./tests/test_update.sh
+# Run both linting and tests
+npm run validate
 ```
+
+### Pre-commit Hooks
+
+Pre-commit hooks automatically run quality checks before each commit to prevent CI failures:
+
+- **Markdown linting** - Ensures consistent markdown formatting
+- **Shell script validation** - Checks shell syntax with shellcheck
+- **File quality checks** - Removes trailing whitespace, ensures proper file endings
+
+**Setup**: Run `./install.sh --hooks` to automatically install and configure pre-commit hooks.
+
+**Manual execution**: `pre-commit run --all-files`
+
+**Skip once**: `git commit --no-verify` (use sparingly)
 
 ### Command Development Guidelines
 

--- a/install.sh
+++ b/install.sh
@@ -186,6 +186,44 @@ install_user() {
     echo "  • /user:cr-upgrade - Shorthand alias for update"
 }
 
+# Setup pre-commit hooks
+setup_precommit_hooks() {
+    print_status "Setting up pre-commit hooks..."
+    
+    # Check if pre-commit is available
+    if ! command -v pre-commit &> /dev/null; then
+        print_status "Installing pre-commit..."
+        
+        # Try different installation methods
+        if command -v pip3 &> /dev/null; then
+            pip3 install pre-commit
+        elif command -v pip &> /dev/null; then
+            pip install pre-commit
+        else
+            print_error "pip/pip3 not found. Please install pre-commit manually: pip install pre-commit"
+            exit 1
+        fi
+    fi
+    
+    # Install hooks
+    print_status "Installing pre-commit hooks..."
+    if pre-commit install; then
+        print_success "Pre-commit hooks installed successfully!"
+        
+        # Test hooks
+        print_status "Testing pre-commit setup..."
+        if pre-commit run --all-files; then
+            print_success "Pre-commit hooks are working correctly!"
+        else
+            print_warning "Pre-commit hooks found some issues (this is normal for initial setup)"
+            print_status "Run 'pre-commit run --all-files' to see and fix any issues"
+        fi
+    else
+        print_error "Failed to install pre-commit hooks"
+        exit 1
+    fi
+}
+
 # Show version information
 show_version() {
     echo "claude-slash installer v$INSTALLER_VERSION"
@@ -261,12 +299,14 @@ case "${1:-}" in
         echo "  --version   Show version information"
         echo "  --update    Update existing installation to latest release"
         echo "  --global    Install to personal directory (~/.claude/commands/)"
+        echo "  --hooks     Setup pre-commit hooks for quality checks"
         echo "  --help      Show this help message"
         echo
         echo "Examples:"
         echo "  $0                    # Install to current project"
         echo "  $0 --global          # Install for personal use"
         echo "  $0 --update          # Update existing installation"
+        echo "  $0 --hooks           # Setup pre-commit hooks"
         echo "  $0 --version         # Show version information"
         exit 0
         ;;
@@ -276,6 +316,9 @@ case "${1:-}" in
         ;;
     --update)
         update_installation
+        ;;
+    --hooks)
+        setup_precommit_hooks
         ;;
     *)
         main "$@"


### PR DESCRIPTION
## Summary
- Add automated pre-commit hooks setup via `./install.sh --hooks` flag
- Enhanced README.md with comprehensive pre-commit documentation  
- Prevents CI failures from linting errors (like the `<commit-hash>` markdown issue from PR #13)

## Technical Changes
- **install.sh**: New `setup_precommit_hooks()` function with multi-platform support
- **README.md**: Added pre-commit setup section with usage examples
- **Quality gates**: Hooks catch markdown/shell issues before commit

## Test Plan
- [x] Verified existing `.pre-commit-config.yaml` configuration is comprehensive
- [x] Tested `./install.sh --hooks` successfully installs and configures pre-commit
- [x] Confirmed pre-commit hooks catch markdown linting errors (same type that failed in PR #13)
- [x] Validated multi-platform installation (pip/pip3 fallback)

🤖 Generated with [Claude Code](https://claude.ai/code)