### PR TITLE
Update Python version requirement to 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Shells",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.13"
 dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
@@ -65,7 +61,7 @@ packages = ["src/claude_slash"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py313']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -87,7 +83,7 @@ multi_line_output = 3
 line_length = 88
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
Remove support for Python versions before 3.13 as requested in issue #40:
- Updated requires-python from >=3.8 to >=3.13
- Removed Python 3.8-3.12 classifiers, kept only 3.13
- Updated black target-version from py38 to py313
- Updated mypy python_version from 3.8 to 3.13