### PR TITLE
feat: Migrate /slash command from bash to Python

### DIFF
--- a/src/claude_slash/commands/slash.py
+++ b/src/claude_slash/commands/slash.py
@@ -1,0 +1,364 @@
+"""
+Slash command implementation providing help display and update functionality.
+
+This module provides the main slash command that:
+- Displays help and available commands (default behavior)
+- Updates local claude-slash commands to the latest release
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import shutil
+from pathlib import Path
+from typing import Any, Optional, List, Dict
+import typer
+from rich.table import Table
+from rich.panel import Panel
+from rich.text import Text
+
+from .base import BaseCommand
+
+
+class SlashCommand(BaseCommand):
+    """
+    Main slash command providing help display and update functionality.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return the command name."""
+        return "slash"
+
+    @property
+    def help_text(self) -> str:
+        """Return the help text for the command."""
+        return "Show help and available commands or update to latest release"
+
+    def execute(self, **kwargs: Any) -> None:
+        """
+        Execute the slash command.
+        
+        Args:
+            **kwargs: Command arguments passed from Typer
+        """
+        subcommand = kwargs.get("subcommand")
+        
+        if subcommand == "update":
+            self._handle_update()
+        else:
+            self._handle_help()
+
+    def create_typer_command(self):
+        """Create a Typer command with custom arguments."""
+        def command_wrapper(
+            subcommand: Optional[str] = typer.Argument(None, help="Subcommand: help (default) or update")
+        ) -> None:
+            """Show help and available commands or update to latest release."""
+            try:
+                self.execute(subcommand=subcommand)
+            except Exception as e:
+                self.console.print(f"[bold red]Error executing {self.name}:[/bold red] {str(e)}")
+                raise typer.Exit(1)
+        
+        return command_wrapper
+
+    def _handle_help(self) -> None:
+        """Handle the help subcommand (default behavior)."""
+        self.console.print(Panel(
+            "[bold blue]📋 Available Claude Slash Commands[/bold blue]",
+            style="blue"
+        ))
+        
+        # Get the commands directory
+        commands_dir = self._find_commands_directory()
+        if not commands_dir:
+            self.error("❌ No claude-slash commands found\n"
+                      "Install commands by downloading and running install.sh from:\n"
+                      "https://github.com/jeremyeder/claude-slash")
+            return
+
+        self.console.print(f"[cyan]Commands installed in: {commands_dir}[/cyan]")
+        self.console.print()
+
+        # Create a table for commands
+        table = Table(show_header=True, header_style="bold green")
+        table.add_column("Command", style="cyan")
+        table.add_column("Description")
+
+        # Process all command files
+        command_files = list(Path(commands_dir).glob("*.md"))
+        if not command_files:
+            self.warning("No command files found in commands directory")
+            return
+
+        for cmd_file in sorted(command_files):
+            filename = cmd_file.stem
+            
+            # Skip this help command to avoid recursion
+            if filename == "slash":
+                continue
+
+            description = self._extract_description(cmd_file)
+            usage = self._extract_usage(cmd_file)
+
+            # Format the command name
+            if usage:
+                cmd_display = usage
+            else:
+                cmd_display = f"/{filename}"
+
+            # Truncate description if too long
+            if len(description) > 60:
+                description = description[:57] + "..."
+
+            table.add_row(cmd_display, description)
+
+        self.console.print(table)
+        self.console.print()
+
+        # Print tips
+        tips_panel = Panel(
+            "[yellow]💡 Tips:[/yellow]\n"
+            "• Type any command above to use it\n"
+            "• Use /learn to extract insights from your current session\n"
+            "• Use /slash update to get the latest commands",
+            style="yellow"
+        )
+        self.console.print(tips_panel)
+        
+        self.console.print()
+        self.console.print("[blue]📖 For more information visit:[/blue] https://github.com/jeremyeder/claude-slash")
+
+    def _handle_update(self) -> None:
+        """Handle the update subcommand."""
+        self.console.print("🔄 Updating claude-slash commands...")
+        self.console.print()
+
+        # Determine installation location
+        install_dir, install_type = self._detect_installation()
+        if not install_dir:
+            self.error("❌ No claude-slash installation found\n"
+                      "Run the installer first:\n"
+                      "curl -sSL https://raw.githubusercontent.com/jeremyeder/claude-slash/main/install.sh -o install.sh && bash install.sh")
+            return
+
+        self.console.print(f"📍 Found {install_type} installation at: {install_dir}")
+
+        # Check for latest release using gh CLI
+        self.console.print("🔍 Checking latest release...")
+        try:
+            result = subprocess.run(
+                ["gh", "api", "repos/jeremyeder/claude-slash/releases/latest"],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            latest_info = json.loads(result.stdout)
+            latest_tag = latest_info.get("tag_name")
+            
+            if not latest_tag:
+                self.error("❌ Could not determine latest version")
+                return
+
+        except subprocess.CalledProcessError:
+            self.error("❌ Failed to check for updates (network error or gh CLI not available)")
+            return
+        except json.JSONDecodeError:
+            self.error("❌ Failed to parse release information")
+            return
+
+        self.console.print(f"📦 Latest release: {latest_tag}")
+
+        # Create backup
+        backup_dir = f"{install_dir}.backup.{self._get_timestamp()}"
+        self.console.print(f"💾 Creating backup at: {backup_dir}")
+        try:
+            shutil.copytree(install_dir, backup_dir)
+        except Exception as e:
+            self.error(f"❌ Failed to create backup: {e}")
+            return
+
+        # Download and extract latest release using gh CLI
+        self.console.print("⬇️  Downloading latest release...")
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                # Download the tarball using gh CLI
+                tarball_path = os.path.join(temp_dir, "claude-slash.tar.gz")
+                subprocess.run(
+                    ["gh", "api", f"repos/jeremyeder/claude-slash/tarball/{latest_tag}"],
+                    stdout=open(tarball_path, "wb"),
+                    check=True
+                )
+
+                # Extract the tarball
+                subprocess.run(
+                    ["tar", "-xz", "-C", temp_dir, "--strip-components=1", "-f", tarball_path],
+                    check=True
+                )
+
+                # Update commands
+                commands_source = os.path.join(temp_dir, ".claude", "commands")
+                if os.path.isdir(commands_source):
+                    self.console.print("🔄 Updating commands...")
+
+                    # Remove old commands
+                    for md_file in Path(install_dir).glob("*.md"):
+                        md_file.unlink()
+
+                    # Copy new commands
+                    for md_file in Path(commands_source).glob("*.md"):
+                        shutil.copy2(md_file, install_dir)
+
+                    self.console.print("✅ Update completed successfully!")
+                    self.console.print(f"📦 Updated to: {latest_tag}")
+                    self.console.print(f"📁 Backup saved to: {backup_dir}")
+                    self.console.print(f"🗑️  Remove backup with: rm -rf {backup_dir}")
+                else:
+                    self.error("❌ Downloaded release doesn't contain command files")
+                    # Restore from backup
+                    self.console.print("🔄 Restoring from backup...")
+                    shutil.rmtree(install_dir)
+                    shutil.move(backup_dir, install_dir)
+                    return
+
+            except subprocess.CalledProcessError as e:
+                self.error(f"❌ Failed to download release: {e}")
+                # Restore from backup
+                self.console.print("🔄 Restoring from backup...")
+                shutil.rmtree(install_dir)
+                shutil.move(backup_dir, install_dir)
+                return
+            except Exception as e:
+                self.error(f"❌ Failed to update commands: {e}")
+                # Restore from backup
+                self.console.print("🔄 Restoring from backup...")
+                shutil.rmtree(install_dir)
+                shutil.move(backup_dir, install_dir)
+                return
+
+        self.console.print()
+        self.console.print("🎉 claude-slash commands updated successfully!")
+
+    def _find_commands_directory(self) -> Optional[str]:
+        """Find the commands directory (project or global)."""
+        # Try to get git root first
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            git_root = result.stdout.strip()
+            commands_dir = os.path.join(git_root, ".claude", "commands")
+            if os.path.isdir(commands_dir):
+                return commands_dir
+        except subprocess.CalledProcessError:
+            pass
+
+        # Fall back to current directory
+        commands_dir = os.path.join(os.getcwd(), ".claude", "commands")
+        if os.path.isdir(commands_dir):
+            return commands_dir
+
+        # Try global installation
+        global_dir = os.path.join(os.path.expanduser("~"), ".claude", "commands")
+        if os.path.isdir(global_dir):
+            return global_dir
+
+        return None
+
+    def _detect_installation(self) -> tuple[Optional[str], str]:
+        """
+        Detect installation type and location.
+        
+        Returns:
+            Tuple of (install_dir, install_type) or (None, "") if not found
+        """
+        # Check project installation
+        project_dir = os.path.join(os.getcwd(), ".claude", "commands")
+        if os.path.isdir(project_dir):
+            return project_dir, "project"
+
+        # Check global installation
+        global_dir = os.path.join(os.path.expanduser("~"), ".claude", "commands")
+        if os.path.isdir(global_dir):
+            return global_dir, "global"
+
+        return None, ""
+
+    def _extract_description(self, file_path: Path) -> str:
+        """
+        Extract command description from markdown file.
+        
+        Args:
+            file_path: Path to the markdown command file
+            
+        Returns:
+            Extracted description or default text
+        """
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+
+            # Try to get the first line after the title that contains descriptive text
+            if len(lines) >= 3:
+                description = lines[2].strip()
+                if description and len(description) >= 10:
+                    return description
+
+            # If that's empty or too short, look for the Description section
+            in_description = False
+            for line in lines:
+                line = line.strip()
+                if line.startswith("## Description"):
+                    in_description = True
+                    continue
+                if in_description and line.startswith("##"):
+                    break
+                if in_description and line and not line.startswith("#"):
+                    return line[:80]
+
+            # Fallback to a generic description
+            return "Custom claude-slash command"
+
+        except Exception:
+            return "Custom claude-slash command"
+
+    def _extract_usage(self, file_path: Path) -> str:
+        """
+        Extract usage from markdown file.
+        
+        Args:
+            file_path: Path to the markdown command file
+            
+        Returns:
+            Extracted usage string or empty string
+        """
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            # Look for usage in code blocks
+            lines = content.split('\n')
+            in_code_block = False
+            for line in lines:
+                line = line.strip()
+                if line.startswith("```"):
+                    in_code_block = not in_code_block
+                    continue
+                if in_code_block and line.startswith("/"):
+                    return line
+
+            return ""
+
+        except Exception:
+            return ""
+
+    def _get_timestamp(self) -> str:
+        """Get a timestamp string for backup directories."""
+        import datetime
+        return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tests/test_slash_command.py
+++ b/tests/test_slash_command.py
@@ -1,0 +1,207 @@
+"""Tests for the slash command functionality."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+
+from claude_slash.commands.slash import SlashCommand
+
+
+class TestSlashCommand:
+    """Test the slash command implementation."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.slash_cmd = SlashCommand()
+
+    def test_command_properties(self):
+        """Test basic command properties."""
+        assert self.slash_cmd.name == "slash"
+        assert "help" in self.slash_cmd.help_text.lower()
+        assert "update" in self.slash_cmd.help_text.lower()
+
+    def test_help_functionality(self, tmp_path):
+        """Test help display functionality."""
+        # Create mock commands directory structure
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        
+        # Create a mock command file
+        test_cmd = commands_dir / "test.md"
+        test_cmd.write_text("""# Test Command
+
+Test command description.
+
+## Usage
+
+```bash
+/test
+```
+
+## Description
+
+This is a test command for testing purposes.
+
+## Implementation
+
+!echo "test"
+""")
+        
+        with patch.object(self.slash_cmd, '_find_commands_directory', return_value=str(commands_dir)):
+            # Should not raise an exception
+            self.slash_cmd._handle_help()
+
+    def test_extract_description(self, tmp_path):
+        """Test description extraction from markdown files."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("""# Test Command
+
+This is the description.
+
+## Usage
+""")
+        
+        description = self.slash_cmd._extract_description(test_file)
+        assert description == "This is the description."
+
+    def test_extract_usage(self, tmp_path):
+        """Test usage extraction from markdown files."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("""# Test Command
+
+Description here.
+
+## Usage
+
+```bash
+/test-command [args]
+```
+""")
+        
+        usage = self.slash_cmd._extract_usage(test_file)
+        assert usage == "/test-command [args]"
+
+    def test_detect_installation_project(self, tmp_path):
+        """Test installation detection for project-level installation."""
+        # Create project-level commands directory
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        
+        with patch('os.getcwd', return_value=str(tmp_path)):
+            install_dir, install_type = self.slash_cmd._detect_installation()
+            assert install_dir == str(commands_dir)
+            assert install_type == "project"
+
+    def test_detect_installation_global(self, tmp_path):
+        """Test installation detection for global installation."""
+        # Create global-level commands directory
+        global_dir = tmp_path / "home" / ".claude" / "commands"
+        global_dir.mkdir(parents=True)
+        
+        with patch('os.getcwd', return_value=str(tmp_path / "workdir")):
+            with patch('os.path.expanduser', return_value=str(tmp_path / "home")):
+                install_dir, install_type = self.slash_cmd._detect_installation()
+                assert install_dir == str(global_dir)
+                assert install_type == "global"
+
+    def test_find_commands_directory_with_git(self, tmp_path):
+        """Test commands directory finding with git repository."""
+        git_root = tmp_path / "repo"
+        commands_dir = git_root / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        
+        mock_result = Mock()
+        mock_result.stdout.strip.return_value = str(git_root)
+        
+        with patch('subprocess.run', return_value=mock_result) as mock_subprocess:
+            result = self.slash_cmd._find_commands_directory()
+            mock_subprocess.assert_called_once()
+            assert result == str(commands_dir)
+
+    @patch('subprocess.run')
+    def test_update_functionality_success(self, mock_subprocess, tmp_path):
+        """Test successful update functionality."""
+        # Mock successful gh CLI calls
+        mock_release_info = {
+            "tag_name": "v1.2.0",
+            "tarball_url": "https://example.com/tarball"
+        }
+        
+        def subprocess_side_effect(cmd, **kwargs):
+            mock_result = Mock()
+            mock_result.returncode = 0
+            
+            if "releases/latest" in str(cmd):
+                mock_result.stdout = json.dumps(mock_release_info)
+            elif "tarball" in str(cmd):
+                # Mock successful tarball download
+                pass
+            elif cmd[0] == "tar":
+                # Mock successful tar extraction
+                pass
+            
+            return mock_result
+        
+        mock_subprocess.side_effect = subprocess_side_effect
+        
+        # Create mock installation
+        install_dir = tmp_path / ".claude" / "commands"
+        install_dir.mkdir(parents=True)
+        (install_dir / "old.md").write_text("old command")
+        
+        # Create mock source directory structure for the update
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_commands = Path(temp_dir) / ".claude" / "commands"
+            source_commands.mkdir(parents=True)
+            (source_commands / "new.md").write_text("new command")
+            
+            with patch.object(self.slash_cmd, '_detect_installation', return_value=(str(install_dir), "project")):
+                with patch('tempfile.TemporaryDirectory') as mock_tempdir:
+                    mock_tempdir.return_value.__enter__.return_value = temp_dir
+                    
+                    # Should not raise an exception
+                    self.slash_cmd._handle_update()
+
+    @patch('subprocess.run')
+    def test_update_network_error(self, mock_subprocess):
+        """Test update handling when network request fails."""
+        mock_subprocess.side_effect = subprocess.CalledProcessError(1, ["gh"])
+        
+        install_dir = "/fake/dir"
+        with patch.object(self.slash_cmd, '_detect_installation', return_value=(install_dir, "project")):
+            with pytest.raises(SystemExit):
+                self.slash_cmd._handle_update()
+
+    def test_get_timestamp(self):
+        """Test timestamp generation."""
+        timestamp = self.slash_cmd._get_timestamp()
+        assert len(timestamp) == 15  # YYYYMMDD-HHMMSS format
+        assert "-" in timestamp
+
+    def test_execute_help_default(self):
+        """Test execute method with default (help) behavior."""
+        with patch.object(self.slash_cmd, '_handle_help') as mock_help:
+            self.slash_cmd.execute()
+            mock_help.assert_called_once()
+
+    def test_execute_update_subcommand(self):
+        """Test execute method with update subcommand."""
+        with patch.object(self.slash_cmd, '_handle_update') as mock_update:
+            self.slash_cmd.execute(subcommand="update")
+            mock_update.assert_called_once()
+
+    def test_create_typer_command(self):
+        """Test Typer command creation."""
+        command_func = self.slash_cmd.create_typer_command()
+        assert callable(command_func)
+        
+        # Test that it doesn't raise an exception with help
+        with patch.object(self.slash_cmd, '_handle_help'):
+            command_func()
+        
+        # Test with update subcommand
+        with patch.object(self.slash_cmd, '_handle_update'):
+            command_func("update")


### PR DESCRIPTION
- Create src/claude_slash/commands/slash.py with full functionality
- Port help display logic with command scanning from .claude/commands/
- Port update functionality using gh CLI instead of curl/API calls
- Implement Rich formatting for colored terminal output
- Handle both project and global installation detection
- Add comprehensive error handling and backup/restore
- Include direct subprocess calls (no wrappers) as requested
- Add test coverage in tests/test_slash_command.py

Resolves #32