### PR TITLE
Add branch protection as default option for /github-init command

### DIFF
--- a/src/claude_slash/commands/github_init.py
+++ b/src/claude_slash/commands/github_init.py
@@ -20,7 +20,7 @@ from .base import BaseCommand
 @dataclass
 class GitHubInitOptions:
     """Options for GitHub repository initialization."""
-    
+
     repo_name: str
     description: Optional[str] = None
     private: bool = True  # Default to private
@@ -32,125 +32,130 @@ class GitHubInitOptions:
     create_website: bool = False
     enable_dependabot: bool = True
     dry_run: bool = False
-    
+
     # GitHub Projects
     create_project: bool = True
     project_template: str = "development"
-    
+
     # Advanced GitHub Automation
     enable_auto_version: bool = True
     enable_auto_merge: bool = True
     enable_claude_review: bool = False
     enable_auto_release: bool = True
+    enable_branch_protection: bool = True
 
 
 class GitHubInitialization:
     """Core GitHub repository initialization logic."""
-    
+
     def __init__(self, options: GitHubInitOptions):
         self.options = options
         self.original_dir = os.getcwd()
         self.created_files = []
-    
+
     def execute(self) -> None:
         """Execute the repository initialization process."""
         if self.options.dry_run:
             self._execute_dry_run()
             return
-        
+
         # Validate prerequisites before starting
         self._validate_prerequisites()
-            
+
         try:
             print(f"🚀 Initializing GitHub repository: {self.options.repo_name}")
-            
+
             # Step 1: Initialize git repository
             self._init_git_repo()
-            
+
             # Step 2: Create initial files
             self._create_initial_files()
-            
+
             # Step 3: Create GitHub Actions workflows
             self._create_github_workflows()
-            
+
             # Step 4: Initialize Docusaurus if requested
             if self.options.create_website:
                 self._initialize_docusaurus()
-            
+
             # Step 5: Create GitHub repository
             self._create_github_repo()
-            
+
             # Step 6: Create GitHub project if requested
             if self.options.create_project:
                 self._create_github_project()
-            
+
             # Step 7: Setup dependabot
             if self.options.enable_dependabot:
                 self._setup_dependabot()
-            
+
             # Step 8: Configure advanced automation
             self._configure_automation()
-            
-            # Step 9: Initial commit and push
+
+            # Step 9: Setup branch protection if enabled
+            if self.options.enable_branch_protection:
+                self._setup_branch_protection()
+
+            # Step 10: Initial commit and push
             self._initial_commit_and_push()
-            
+
             print(f"✅ Repository '{self.options.repo_name}' initialized successfully!")
             print(f"📂 Local directory: {os.getcwd()}")
             print(f"🔗 GitHub URL: https://github.com/{self._get_github_user()}/{self.options.repo_name}")
-            
+
         except Exception as e:
             print(f"❌ Error during initialization: {e}")
             self._rollback()
             raise
-    
+
     def _validate_prerequisites(self) -> None:
         """Validate that all prerequisites are available."""
         # Check if gh CLI is available and authenticated
-        result = subprocess.run(['gh', 'auth', 'status'], 
+        result = subprocess.run(['gh', 'auth', 'status'],
                               capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError("GitHub CLI (gh) is not installed or not authenticated")
-        
+
         # Check if git is available
-        result = subprocess.run(['git', '--version'], 
+        result = subprocess.run(['git', '--version'],
                               capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError("Git is not installed")
-        
+
         # Check if repo name already exists locally
         if Path(self.options.repo_name).exists():
             raise RuntimeError(f"Directory '{self.options.repo_name}' already exists")
-    
+
     def _get_github_user(self) -> str:
         """Get the current GitHub username."""
-        result = subprocess.run(['gh', 'api', 'user'], 
+        result = subprocess.run(['gh', 'api', 'user'],
                               capture_output=True, text=True)
         if result.returncode == 0:
             import json
             user_data = json.loads(result.stdout)
             return user_data.get('login', 'unknown')
         return 'unknown'
-    
+
     def _init_git_repo(self) -> None:
         """Initialize a new git repository."""
         # Create directory and initialize git
         os.makedirs(self.options.repo_name)
         os.chdir(self.options.repo_name)
-        
+
         subprocess.run(['git', 'init'], check=True)
         subprocess.run(['git', 'branch', '-M', self.options.default_branch], check=True)
-    
+
     def _create_initial_files(self) -> None:
         """Create initial files for the repository."""
         if self.options.readme:
             self._create_readme()
-        
+
         if self.options.gitignore:
             self._create_gitignore()
-        
+
         if self.options.license:
             self._create_license()
-    
+
     def _create_readme(self) -> None:
         """Create a README.md file."""
         content = f"""# {self.options.repo_name}
@@ -172,7 +177,7 @@ Contributions are welcome! Please read our contributing guidelines.
         with open("README.md", "w") as f:
             f.write(content)
         self.created_files.append("README.md")
-    
+
     def _create_gitignore(self) -> None:
         """Create .gitignore file."""
         # Use gh to get gitignore template if available
@@ -256,7 +261,7 @@ Thumbs.db
             with open(".gitignore", "w") as f:
                 f.write(basic_gitignore)
             self.created_files.append(".gitignore")
-    
+
     def _create_license(self) -> None:
         """Create LICENSE file."""
         # For simplicity, create a basic MIT license placeholder
@@ -286,12 +291,12 @@ SOFTWARE.
         with open("LICENSE", "w") as f:
             f.write(content)
         self.created_files.append("LICENSE")
-    
+
     def _create_github_workflows(self) -> None:
         """Create GitHub Actions workflows."""
         workflows_dir = Path(".github/workflows")
         workflows_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Create a basic CI workflow
         ci_workflow = """name: CI
 
@@ -304,37 +309,37 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
-    
+
     - name: Run tests
       run: pytest
 """
-        
+
         with open(workflows_dir / "ci.yml", "w") as f:
             f.write(ci_workflow)
         self.created_files.append(".github/workflows/ci.yml")
-    
+
     def _initialize_docusaurus(self) -> None:
         """Initialize Docusaurus documentation site."""
         print("📚 Setting up Docusaurus documentation site...")
         # This is a placeholder - real implementation would need Node.js setup
         docs_dir = Path("docs")
         docs_dir.mkdir(exist_ok=True)
-        
+
         with open(docs_dir / "index.md", "w") as f:
             f.write(f"""# {self.options.repo_name} Documentation
 
@@ -345,34 +350,34 @@ Welcome to the documentation for {self.options.repo_name}.
 {self.options.description or "Add your project description here."}
 """)
         self.created_files.append("docs/index.md")
-    
+
     def _create_github_repo(self) -> None:
         """Create the GitHub repository."""
         visibility = "private" if self.options.private else "public"
-        
-        cmd = ['gh', 'repo', 'create', self.options.repo_name, 
+
+        cmd = ['gh', 'repo', 'create', self.options.repo_name,
                f'--{visibility}']
-        
+
         if self.options.description:
             cmd.extend(['--description', self.options.description])
-        
+
         subprocess.run(cmd, check=True)
-    
+
     def _create_github_project(self) -> None:
         """Create GitHub project board."""
         print("📋 Creating GitHub project...")
         # Repository-level project creation
         subprocess.run([
-            'gh', 'project', 'create', 
+            'gh', 'project', 'create',
             '--title', f'{self.options.repo_name} Development',
             '--body', f'Development tracking for {self.options.repo_name}'
         ], check=True)
-    
+
     def _setup_dependabot(self) -> None:
         """Setup Dependabot configuration."""
         dependabot_dir = Path(".github")
         dependabot_dir.mkdir(exist_ok=True)
-        
+
         dependabot_config = """version: 2
 updates:
   - package-ecosystem: "pip"
@@ -388,35 +393,65 @@ updates:
     reviewers:
       - "@me"
 """
-        
+
         with open(dependabot_dir / "dependabot.yml", "w") as f:
             f.write(dependabot_config)
         self.created_files.append(".github/dependabot.yml")
-    
+
+    def _setup_branch_protection(self) -> None:
+        """Setup branch protection rules for the main branch."""
+        print("🛡️ Setting up branch protection rules...")
+
+        user = self._get_github_user()
+        repo_full_name = f"{user}/{self.options.repo_name}"
+
+        try:
+            # Create branch protection rule using GitHub CLI
+            cmd = [
+                'gh', 'api', '--method', 'PUT',
+                f'/repos/{repo_full_name}/branches/{self.options.default_branch}/protection',
+                '--field', 'required_status_checks={"strict":true,"checks":[]}',
+                '--field', 'enforce_admins=false',
+                '--field', 'required_pull_request_reviews={"required_approving_review_count":1,"dismiss_stale_reviews":true,"require_code_owner_reviews":false}',
+                '--field', 'restrictions=null',
+                '--field', 'allow_force_pushes=false',
+                '--field', 'allow_deletions=false'
+            ]
+
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode == 0:
+                print("✅ Branch protection rules configured successfully")
+            else:
+                print(f"⚠️ Warning: Could not set up branch protection: {result.stderr}")
+
+        except Exception as e:
+            print(f"⚠️ Warning: Failed to setup branch protection: {e}")
+
     def _configure_automation(self) -> None:
         """Configure advanced GitHub automation."""
         if self.options.enable_auto_version:
             print("🔄 Configuring automatic versioning...")
-        
+
         if self.options.enable_auto_merge:
             print("🔄 Configuring auto-merge for dependabot...")
-        
+
         if self.options.enable_auto_release:
             print("🔄 Configuring automatic releases...")
-    
+
     def _initial_commit_and_push(self) -> None:
         """Make initial commit and push to GitHub."""
         subprocess.run(['git', 'add', '.'], check=True)
         subprocess.run(['git', 'commit', '-m', 'Initial commit'], check=True)
-        
+
         # Add remote and push
         user = self._get_github_user()
-        subprocess.run(['git', 'remote', 'add', 'origin', 
-                       f'git@github.com:{user}/{self.options.repo_name}.git'], 
+        subprocess.run(['git', 'remote', 'add', 'origin',
+                       f'git@github.com:{user}/{self.options.repo_name}.git'],
                       check=True)
-        subprocess.run(['git', 'push', '-u', 'origin', self.options.default_branch], 
+        subprocess.run(['git', 'push', '-u', 'origin', self.options.default_branch],
                       check=True)
-    
+
     def _execute_dry_run(self) -> None:
         """Show what would be created without actually creating it."""
         print("🔍 DRY RUN MODE - Preview of what would be created:")
@@ -432,29 +467,30 @@ updates:
         print(f"🌐 Website: {'✓' if self.options.create_website else '✗'}")
         print(f"📋 Project board: {'✓' if self.options.create_project else '✗'}")
         print(f"🤖 Dependabot: {'✓' if self.options.enable_dependabot else '✗'}")
+        print(f"🛡️ Branch protection: {'✓' if self.options.enable_branch_protection else '✗'}")
         print("🎯 GitHub Actions workflows: CI/CD")
-    
+
     def _rollback(self) -> None:
         """Rollback changes on failure."""
         try:
             print("🔄 Rolling back changes...")
-            
+
             # Change back to original directory
             os.chdir(self.original_dir)
-            
+
             # Try to delete the GitHub repository if it was created
             try:
                 user = self._get_github_user()
-                subprocess.run(['gh', 'repo', 'delete', f'{user}/{self.options.repo_name}', '--yes'], 
+                subprocess.run(['gh', 'repo', 'delete', f'{user}/{self.options.repo_name}', '--yes'],
                               capture_output=True)
             except Exception:
                 pass
-            
+
             # Remove local directory
             import shutil
             if Path(self.options.repo_name).exists():
                 shutil.rmtree(self.options.repo_name)
-                
+
         except Exception as e:
             print(f"⚠️ Error during rollback: {e}")
 
@@ -462,22 +498,22 @@ updates:
 class GitHubInitCommand(BaseCommand):
     """
     Initialize and configure a new GitHub repository with best practices.
-    
+
     This command creates a complete repository setup including:
     - Git repository initialization
     - README, .gitignore, and LICENSE files
-    - GitHub Actions CI/CD workflows  
+    - GitHub Actions CI/CD workflows
     - Optional Docusaurus documentation site
     - GitHub project board
     - Dependabot configuration
     - Advanced automation features
     """
-    
+
     @property
     def name(self) -> str:
         """Return the command name."""
         return "github-init"
-    
+
     @property
     def help_text(self) -> str:
         """Return the help text for the command."""
@@ -493,17 +529,18 @@ class GitHubInitCommand(BaseCommand):
             "Features:\n"
             "• 🔒 Private repositories by default (security-first)\n"
             "• 🚀 Complete CI/CD workflow setup\n"
+            "• 🛡️ Branch protection rules enabled by default\n"
             "• 📚 Optional Docusaurus documentation site\n"
             "• 📋 Repository-level project boards\n"
             "• 🤖 Automated dependency management\n"
             "• 🔄 Rollback on failure\n"
             "• 👀 Dry-run preview mode"
         )
-    
+
     def execute(self, **kwargs: Any) -> None:
         """
         Execute the GitHub init command.
-        
+
         Args:
             **kwargs: Command arguments passed from Typer
         """
@@ -513,7 +550,7 @@ class GitHubInitCommand(BaseCommand):
             if not repo_name:
                 self.error("Repository name is required")
                 return
-            
+
             # Build options from arguments
             options = GitHubInitOptions(
                 repo_name=repo_name,
@@ -528,21 +565,22 @@ class GitHubInitCommand(BaseCommand):
                 create_project=kwargs.get("create_project", True),
                 enable_auto_version=kwargs.get("enable_auto_version", True),
                 enable_auto_merge=kwargs.get("enable_auto_merge", True),
-                enable_auto_release=kwargs.get("enable_auto_release", True)
+                enable_auto_release=kwargs.get("enable_auto_release", True),
+                enable_branch_protection=kwargs.get("enable_branch_protection", True)
             )
-            
+
             # Execute the initialization
             initializer = GitHubInitialization(options)
             initializer.execute()
-            
+
             self.success(f"Repository '{repo_name}' initialized successfully!")
-            
+
         except Exception as e:
             self.error(f"Failed to initialize repository: {str(e)}")
-    
+
     def create_typer_command(self):
         """Create a Typer command with custom arguments."""
-        
+
         def command_wrapper(
             repo_name: str = typer.Argument(..., help="Name of the repository to create"),
             description: Optional[str] = typer.Option(None, "--description", "-d", help="Repository description"),
@@ -555,7 +593,8 @@ class GitHubInitCommand(BaseCommand):
             create_project: bool = typer.Option(True, "--create-project/--no-project", help="Create GitHub project board"),
             enable_auto_version: bool = typer.Option(True, "--enable-auto-version/--no-auto-version", help="Enable automatic versioning"),
             enable_auto_merge: bool = typer.Option(True, "--enable-auto-merge/--no-auto-merge", help="Enable auto-merge for dependabot"),
-            enable_auto_release: bool = typer.Option(True, "--enable-auto-release/--no-auto-release", help="Enable automatic releases")
+            enable_auto_release: bool = typer.Option(True, "--enable-auto-release/--no-auto-release", help="Enable automatic releases"),
+            enable_branch_protection: bool = typer.Option(True, "--enable-branch-protection/--no-branch-protection", help="Enable branch protection rules")
         ) -> None:
             """Initialize a new GitHub repository with best practices."""
             try:
@@ -571,12 +610,13 @@ class GitHubInitCommand(BaseCommand):
                     create_project=create_project,
                     enable_auto_version=enable_auto_version,
                     enable_auto_merge=enable_auto_merge,
-                    enable_auto_release=enable_auto_release
+                    enable_auto_release=enable_auto_release,
+                    enable_branch_protection=enable_branch_protection
                 )
             except Exception as e:
                 self.console.print(
                     f"[bold red]Error executing {self.name}:[/bold red] {str(e)}"
                 )
                 raise typer.Exit(1)
-        
+
         return command_wrapper


### PR DESCRIPTION
## Summary

This PR adds branch protection rules as a default enabled option for the `/github-init` slash command, enhancing the security-first approach of the command.

### Changes Made

- ✅ **Added `enable_branch_protection` option** to `GitHubInitOptions` dataclass (defaults to `True`)
- ✅ **Implemented `_setup_branch_protection()` method** that configures protection rules via GitHub CLI
- ✅ **Integrated branch protection setup** into the main execution flow (Step 9)
- ✅ **Added CLI option** `--enable-branch-protection/--no-branch-protection` to Typer command
- ✅ **Updated help text and dry-run output** to display branch protection status with 🛡️ icon

### Branch Protection Rules Configured

- Require pull request reviews (1 approving review required)
- Dismiss stale PR reviews when new commits are pushed
- Require status checks to pass before merging  
- Prevent force pushes to protected branch
- Prevent deletion of protected branch
- No admin enforcement bypass (maintains flexibility)

### Security Benefits

- **Default-enabled protection** follows the existing security-first pattern (like private repos by default)
- **Prevents direct pushes** to main branch, enforcing code review workflow
- **Automatic stale review dismissal** ensures reviews stay current
- **Status check requirements** integrate with CI/CD workflows

### CLI Usage Examples

```bash
# Branch protection enabled by default
/github-init my-secure-project

# Explicitly disable branch protection if needed
/github-init legacy-project --no-branch-protection

# View what would be configured (dry-run)
/github-init test-project --dry-run
```

### Test Plan

- [ ] Test `/github-init` command with branch protection enabled (default)
- [ ] Test `/github-init` command with `--no-branch-protection` flag
- [ ] Verify branch protection rules are correctly applied to main branch
- [ ] Test dry-run mode shows branch protection status
- [ ] Verify error handling when GitHub API calls fail

🤖 Generated with [Claude Code](https://claude.ai/code)