### PR TITLE
Enhance /github-init to always create basic .gitignore file

### DIFF
--- a/src/claude_slash/commands/github_init.py
+++ b/src/claude_slash/commands/github_init.py
@@ -156,8 +156,8 @@ class GitHubInitialization:
         if self.options.readme:
             self._create_readme()
 
-        if self.options.gitignore:
-            self._create_gitignore()
+        # Always create a .gitignore file (basic one if no template specified)
+        self._create_gitignore()
 
         if self.options.license:
             self._create_license()
@@ -186,23 +186,26 @@ Contributions are welcome! Please read our contributing guidelines.
 
     def _create_gitignore(self) -> None:
         """Create .gitignore file."""
-        # Use gh to get gitignore template if available
-        try:
-            result = subprocess.run(
-                ["gh", "api", f"/gitignore/templates/{self.options.gitignore}"],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode == 0:
-                import json
+        content = None
 
-                data = json.loads(result.stdout)
-                content = data.get("source", "")
-                with open(".gitignore", "w") as f:
-                    f.write(content)
-                self.created_files.append(".gitignore")
-        except Exception:
-            # Fallback to basic gitignore
+        # Use gh to get gitignore template if specific template was requested
+        if self.options.gitignore:
+            try:
+                result = subprocess.run(
+                    ["gh", "api", f"/gitignore/templates/{self.options.gitignore}"],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    import json
+
+                    data = json.loads(result.stdout)
+                    content = data.get("source", "")
+            except Exception:
+                pass  # Will fall through to basic gitignore
+
+        # Use basic gitignore if no template specified or template fetch failed
+        if not content:
             basic_gitignore = """# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -266,9 +269,12 @@ venv.bak/
 ehthumbs.db
 Thumbs.db
 """
-            with open(".gitignore", "w") as f:
-                f.write(basic_gitignore)
-            self.created_files.append(".gitignore")
+            content = basic_gitignore
+
+        # Write the content to .gitignore file
+        with open(".gitignore", "w") as f:
+            f.write(content)
+        self.created_files.append(".gitignore")
 
     def _create_license(self) -> None:
         """Create LICENSE file."""
@@ -972,8 +978,7 @@ updates:
         if self.options.description:
             print(f"📝 Description: {self.options.description}")
         print(f"📄 README: {'✓' if self.options.readme else '✗'}")
-        if self.options.gitignore:
-            print(f"🚫 .gitignore: {self.options.gitignore}")
+        print(f"🚫 .gitignore: {self.options.gitignore or 'basic'}")
         if self.options.license:
             print(f"📜 License: {self.options.license}")
         print(f"🌐 Website: {'✓' if self.options.create_website else '✗'}")


### PR DESCRIPTION
## Summary

- Enhanced `/github-init` command to always create a `.gitignore` file, even when no specific template is requested
- Modified both CLI and slash command versions for consistency
- Updated dry-run output to clearly show gitignore creation

## Changes Made

### Core Functionality
- **Modified `_create_initial_files()`**: Now always calls `_create_gitignore()` instead of only when a template is specified
- **Enhanced `_create_gitignore()`**: Creates comprehensive basic template when no specific template requested via `--gitignore` flag
- **Updated dry-run output**: Shows `🚫 .gitignore: basic` when no template specified, or `🚫 .gitignore: [template]` when specific template is used

### Basic Template Coverage
The default basic template includes:
- **Python**: `__pycache__/`, `*.pyc`, virtual environments, distribution files
- **Node.js**: `node_modules/`, build artifacts
- **IDE files**: VS Code (`.vscode/`), IntelliJ (`.idea/`), Vim swap files
- **OS files**: macOS (`.DS_Store`), Windows (`Thumbs.db`)
- **Common patterns**: Build directories, test coverage, temporary files

### File Changes
- **Slash command**: `.claude/commands/github_init.py`
- **CLI command**: `src/claude_slash/commands/github_init.py`

## Test Plan

- [x] Verified dry-run shows `basic` when no `--gitignore` specified
- [x] Verified dry-run shows template name when `--gitignore Python` specified  
- [x] Confirmed both CLI and slash command versions work consistently
- [x] Ensured backward compatibility - existing `--gitignore` behavior unchanged

## Benefits

✅ **Better developer experience**: Every repository gets proper version control hygiene from day one
✅ **Consistency**: No more forgotten gitignore files leading to committed build artifacts
✅ **Comprehensive coverage**: Basic template handles most common development scenarios  
✅ **Backward compatible**: Existing `--gitignore` template functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)